### PR TITLE
Add extensive unit tests

### DIFF
--- a/tests/chat-thread-title.test.ts
+++ b/tests/chat-thread-title.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("agents/ai-chat-agent", () => ({
+  AIChatAgent: class {
+    messages: any[] = [];
+    sql() {}
+    fetch() { return Promise.resolve(new Response()); }
+  },
+}));
+
+vi.mock("agents", () => ({ routeAgentRequest: vi.fn() }));
+vi.mock("@ai-sdk/openai", () => ({ openai: () => ({}) }));
+
+import { Chat } from "../src/server";
+
+describe("Chat.generateThreadTitle", () => {
+  it("uses first user message", () => {
+    const chat = new Chat({ env: {} as any });
+    (chat as any).messages = [{ role: "user", content: "Hello world" }];
+    const title = (chat as any).generateThreadTitle();
+    expect(title).toBe("Hello world");
+  });
+
+  it("falls back to default", () => {
+    const chat = new Chat({ env: {} as any });
+    (chat as any).messages = [];
+    const title = (chat as any).generateThreadTitle();
+    expect(title).toContain("New Chat");
+  });
+});

--- a/tests/lib-utils.test.ts
+++ b/tests/lib-utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+
+vi.mock("clsx", () => ({
+  default: (...args: any[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("tailwind-merge", () => ({
+  twMerge: (...args: any[]) => args.join(" "),
+}));
+
+import { cn } from "../src/lib/utils";
+
+describe("cn helper", () => {
+  it("merges class names", () => {
+    expect(cn("a", false && "b", "c")).toBe("a c");
+  });
+});

--- a/tests/processToolCalls.test.ts
+++ b/tests/processToolCalls.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@ai-sdk/ui-utils", () => ({
+  formatDataStreamPart: (type: string, data: any) => ({ type, data }),
+}));
+
+vi.mock("ai", () => ({
+  convertToCoreMessages: (m: any) => m,
+}));
+
+import { processToolCalls } from "../src/utils";
+import { APPROVAL } from "../src/shared";
+
+const writer = { write: vi.fn() } as any;
+
+describe("processToolCalls", () => {
+  it("returns original messages when no tool invocation", async () => {
+    const messages = [{ id: "1", role: "user", content: "hi" } as any];
+    const result = await processToolCalls({
+      tools: {},
+      dataStream: writer,
+      messages,
+      executions: {},
+    });
+    expect(result).toEqual(messages);
+  });
+
+  it("executes tool when approved", async () => {
+    const exec = vi.fn().mockResolvedValue("ok");
+    const messages = [
+      {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-invocation",
+            toolInvocation: {
+              toolName: "t",
+              state: "result",
+              result: APPROVAL.YES,
+              args: { a: 1 },
+              toolCallId: "tc1",
+            },
+          },
+        ],
+      } as any,
+    ];
+    const out = await processToolCalls({
+      tools: { t: {} } as any,
+      dataStream: writer,
+      messages,
+      executions: { t: exec },
+    });
+    expect(exec).toHaveBeenCalled();
+    expect(writer.write).toHaveBeenCalledWith({
+      type: "tool_result",
+      data: { toolCallId: "tc1", result: "ok" },
+    });
+    expect(out[out.length - 1].parts[0].toolInvocation.result).toBe("ok");
+  });
+
+  it("handles denied execution", async () => {
+    writer.write.mockClear();
+    const messages = [
+      {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-invocation",
+            toolInvocation: {
+              toolName: "t",
+              state: "result",
+              result: APPROVAL.NO,
+              args: {},
+              toolCallId: "tc2",
+            },
+          },
+        ],
+      } as any,
+    ];
+    const out = await processToolCalls({
+      tools: { t: {} } as any,
+      dataStream: writer,
+      messages,
+      executions: {},
+    });
+    expect(writer.write).toHaveBeenCalled();
+    expect(out[out.length - 1].parts[0].toolInvocation.result).toContain("denied");
+  });
+});

--- a/tests/session-utils.test.ts
+++ b/tests/session-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { createSessionCookie, getSession, clearSessionCookie, type SessionData } from "../src/auth/session";
+
+const sample: SessionData = { userId: "123", username: "tester" };
+
+describe("session cookie helpers", () => {
+  it("creates and decodes a session cookie", async () => {
+    const cookie = createSessionCookie(sample, { maxAge: 100 });
+    expect(cookie).toContain("__session=");
+    const value = cookie.split("__session=")[1].split(";")[0];
+    const decoded = JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    expect(decoded).toEqual(sample);
+    const req = new Request("http://x", { headers: { Cookie: cookie } });
+    const result = await getSession(req);
+    expect(result).toEqual(sample);
+  });
+
+  it("returns null for missing or bad cookie", async () => {
+    expect(await getSession(new Request("http://x"))).toBeNull();
+    const bad = new Request("http://x", { headers: { Cookie: "__session=bad" } });
+    expect(await getSession(bad)).toBeNull();
+  });
+
+  it("clears session cookie", () => {
+    const cleared = clearSessionCookie();
+    expect(cleared).toContain("Max-Age=0");
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("ai", () => ({
+  tool: (def: any) => def,
+}));
+
+const scheduleMock = vi.fn();
+const getSchedulesMock = vi.fn();
+const cancelMock = vi.fn();
+
+vi.mock("agents", () => ({
+  getCurrentAgent: () => ({
+    agent: {
+      schedule: scheduleMock,
+      getSchedules: getSchedulesMock,
+      cancelSchedule: cancelMock,
+    },
+  }),
+}));
+
+vi.mock("agents/schedule", () => ({
+  unstable_scheduleSchema: {},
+}));
+
+import { tools, executions } from "../src/tools";
+
+describe("tool implementations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scheduleTask works for scheduled", async () => {
+    const res = await tools.scheduleTask.execute({
+      when: { type: "scheduled", date: "2024" },
+      description: "d",
+    });
+    expect(scheduleMock).toHaveBeenCalledWith("2024", "executeTask", "d");
+    expect(res).toContain("scheduled");
+  });
+
+  it("scheduleTask handles no schedule", async () => {
+    const res = await tools.scheduleTask.execute({
+      when: { type: "no-schedule" },
+      description: "d",
+    } as any);
+    expect(res).toBe("Not a valid schedule input");
+  });
+
+  it("scheduleTask throws on invalid type", async () => {
+    await expect(
+      tools.scheduleTask.execute({ when: { type: "bad" } as any, description: "d" })
+    ).rejects.toThrow();
+  });
+
+  it("getScheduledTasks returns tasks", async () => {
+    getSchedulesMock.mockReturnValue(["t1"]);
+    const res = await tools.getScheduledTasks.execute({});
+    expect(res).toEqual(["t1"]);
+  });
+
+  it("getScheduledTasks handles empty", async () => {
+    getSchedulesMock.mockReturnValue([]);
+    const res = await tools.getScheduledTasks.execute({});
+    expect(res).toBe("No scheduled tasks found.");
+  });
+
+  it("cancelScheduledTask calls cancel", async () => {
+    const res = await tools.cancelScheduledTask.execute({ taskId: "x" });
+    expect(cancelMock).toHaveBeenCalledWith("x");
+    expect(res).toContain("x");
+  });
+
+  it("getWeatherInformation execution", async () => {
+    const res = await executions.getWeatherInformation({ city: "Paris" });
+    expect(res).toContain("Paris");
+  });
+
+  it("getLocalTime returns value", async () => {
+    const res = await tools.getLocalTime.execute({ location: "NY" });
+    expect(res).toBe("10am");
+  });
+});


### PR DESCRIPTION
## Summary
- create session utility tests
- add processToolCalls tests
- test tool implementations and schedules
- cover class helper function generateThreadTitle
- cover CN helper

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e7ebbc128832985f7b0ea5341cddb