### PR TITLE
Implement scheduled task notifications

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -257,7 +257,7 @@ If the user asks to schedule a task, use the schedule tool to schedule the task.
     const taskMessage: Message = {
       id: generateId(),
       role: "user",
-      content: `Running scheduled task: ${description}`,
+      content: `scheduled message: Running scheduled task: ${description}`,
       createdAt: new Date(),
     };
 

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("agents/ai-chat-agent", () => ({
+  AIChatAgent: class {
+    messages: any[] = [];
+    env: any;
+    constructor({ env }: { env: any }) {
+      this.env = env;
+    }
+    sql() {}
+    async fetch() {
+      return Promise.resolve(new Response());
+    }
+    async serializeDbOperation(fn: () => any) {
+      return await fn();
+    }
+    async updateThreadMetadata() {}
+    async saveMessages(m: any[]) {
+      this.messages = m;
+    }
+  },
+}));
+
+vi.mock("agents", () => ({ routeAgentRequest: vi.fn() }));
+vi.mock("@ai-sdk/openai", () => ({ openai: () => ({}) }));
+
+import { Chat } from "../src/server";
+
+describe("Chat.executeTask", () => {
+  it("adds scheduled message prefix", async () => {
+    const chat = new Chat({ env: {} as any });
+    await (chat as any).executeTask("do something", {} as any);
+    expect((chat as any).messages[0].content).toContain("scheduled message");
+  });
+});


### PR DESCRIPTION
## Summary
- prefix scheduled task messages with `scheduled message:` so the UI shows an icon
- test `executeTask` notification message

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e99ab3c9c8329abea8a5fd0ec062c